### PR TITLE
refactor getHandler to just create a RequestHandler for the action form

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
 
 sudo: false
 
@@ -19,7 +20,6 @@ before_script:
   - composer install --no-interaction
   - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "7.1" ]; then composer require satooshi/php-coveralls:~0.6@stable; fi;'
   - mkdir -p build/logs
-
 script:
   - composer code-style
   - bin/phpunit -c phpunit.xml --color=always --coverage-clover=build/logs/clover.xml --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_script:
   - composer install --no-interaction
   - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "7.1" ]; then composer require satooshi/php-coveralls:~0.6@stable; fi;'
   - mkdir -p build/logs
+
 script:
   - composer code-style
   - bin/phpunit -c phpunit.xml --color=always --coverage-clover=build/logs/clover.xml --coverage-text

--- a/riki-dev/app/Http/Controller/AbstractController.php
+++ b/riki-dev/app/Http/Controller/AbstractController.php
@@ -4,12 +4,10 @@ namespace App\Http\Controller;
 
 use App\Application;
 use function GuzzleHttp\Psr7\stream_for;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\RequestHandlerInterface;
 use Tal\ServerResponse;
 
-abstract class AbstractController implements RequestHandlerInterface
+abstract class AbstractController
 {
     /** @var Application */
     protected $app;
@@ -24,21 +22,6 @@ abstract class AbstractController implements RequestHandlerInterface
     {
         $this->app = $app;
         $this->action = $action;
-    }
-
-    public function handle(ServerRequestInterface $request): ResponseInterface
-    {
-        $this->request = $request;
-        $action = $this->action;
-
-        if (!method_exists($this, $action)) {
-            throw new \Exception(sprintf('Action %s is unknown in %s', $action, static::class));
-        }
-
-        $arguments = $request->getAttribute('arguments') ?? [];
-        $response = call_user_func([$this, $action], ...array_values($arguments));
-
-        return $response;
     }
 
     /**

--- a/riki-dev/app/Http/Controller/ErrorController.php
+++ b/riki-dev/app/Http/Controller/ErrorController.php
@@ -2,30 +2,31 @@
 
 namespace App\Http\Controller;
 
+use Psr\Http\Message\ServerRequestInterface;
 use Tal\ServerResponse;
 
 class ErrorController extends AbstractController
 {
-    public function notFound(): ServerResponse
+    public function notFound(ServerRequestInterface $request): ServerResponse
     {
         return $this->error(404, 'File Not Found', sprintf(
             'The requested url %s is not available on this server. ' .
             'Either you misspelled the url or you clicked on a dead link.',
-            $this->request->getUri()->getPath()
+            $request->getUri()->getPath()
         ));
     }
 
-    public function methodNotAllowed(array $allowedMethods)
+    public function methodNotAllowed(ServerRequestInterface $request, array $allowedMethods)
     {
         return $this->error(405, 'Method Not Allowed', sprintf(
             'The requested method is not allowed for the resource %s.<br />' .
             'Allowed methods: %s',
-            $this->request->getUri()->getPath(),
+            $request->getUri()->getPath(),
             implode(', ', $allowedMethods)
         ));
     }
 
-    public function unexpectedError(\Throwable $exception = null): ServerResponse
+    public function unexpectedError(ServerRequestInterface $request, \Throwable $exception = null): ServerResponse
     {
         return $this->error(500, 'Unexpected Error', 'Whoops something went wrong!', $exception);
     }

--- a/riki-dev/app/Http/HttpKernel.php
+++ b/riki-dev/app/Http/HttpKernel.php
@@ -172,7 +172,7 @@ class HttpKernel extends \App\Kernel
      * @param callable $callable
      * @return bool
      */
-    protected function isStatic(callable $callable): bool
+    protected function isStatic($callable): bool
     {
         if (is_array($callable)) {
             list($class, $method) = $callable;

--- a/riki-dev/app/Http/HttpKernel.php
+++ b/riki-dev/app/Http/HttpKernel.php
@@ -82,46 +82,30 @@ class HttpKernel extends \App\Kernel
      */
     public function getHandler($handler)
     {
-        if (is_callable($handler)) {
-            switch (gettype($handler)) {
-                case 'string':
-                    if (strpos($handler, '::') === false) {
-                        return $handler;
-                    }
-                    list($class, $method) = explode('::', $handler);
-                    break;
-
-                case 'array':
-                    if (is_object($handler[0])) {
-                        return $handler;
-                    }
-                    list($class, $method) = $handler;
-                    break;
-
-                default:
-                case 'object':
-                    return $handler;
-            }
-            // for static calls we have to check more... because is callable returns true for non static methods
-            if (class_exists($class)) {
-                $class = new \ReflectionClass($class);
-                $method = $class->getMethod($method);
-                if (!$class->isAbstract() && $method->isStatic() && $method->isPublic() && !$method->isAbstract()) {
-                    return $handler;
-                }
-            }
+        if (!is_string($handler) && !is_callable($handler)) {
+            throw new \InvalidArgumentException(
+                '$handler has to be a callable, a string in form "method@Controller" or a class name'
+            );
         }
 
-        if (is_array($handler)) {
-            $class = array_shift($handler);
-            $args = $handler;
-        } elseif (is_string($handler)) {
-            $class = $handler;
-            $args = [];
-            if (1 < $pos = strpos($handler, '@')) {
-                $class = substr($handler, $pos + 1);
-                $args[] = substr($handler, 0, $pos);
+        if (is_string($handler)) {
+            if (is_callable($handler) && $this->isStatic($handler)) {
+                return $handler;
             }
+
+            $class = $handler;
+            if (($pos = strpos($handler, '@')) >= 1) {
+                $class = substr($handler, $pos + 1);
+                $method = substr($handler, 0, $pos);
+            }
+        } elseif (is_array($handler)) {
+            if (is_object($handler[0]) || $this->isStatic($handler)) {
+                return $handler;
+            }
+
+            list($class, $method) = $handler;
+        } else {
+            return $handler;
         }
 
         if (!class_exists($class)) {
@@ -131,11 +115,11 @@ class HttpKernel extends \App\Kernel
             $class = self::CONTROLLER_NAMESPACE . '\\' . $class;
         }
 
-        if (substr($class, 0, strlen(self::CONTROLLER_NAMESPACE)) === self::CONTROLLER_NAMESPACE) {
-            array_unshift($args, $this->app);
+        if (!isset($method)) {
+            return $this->app->make($class);
         }
 
-        return $this->app->make($class, ...$args);
+        return new RequestHandler($this->app, $class, $method);
     }
 
     public function getErrorHandlers(): array
@@ -149,8 +133,8 @@ class HttpKernel extends \App\Kernel
                 $request = (self::$lastRequest ?? ServerRequest::fromGlobals())
                     ->withAttribute('arguments', ['exception' => $exception]);
                 /** @var ErrorController $errorController */
-                $errorController = self::getHandler([ErrorController::class, 'unexpectedError']);
-                $errorController->handle($request)->send();
+                $handler = new RequestHandler($this->app, ErrorController::class, 'unexpectedError');
+                $handler->handle($request)->send();
                 return Handler::QUIT;
             }];
         }
@@ -177,5 +161,39 @@ class HttpKernel extends \App\Kernel
         $router->addGroup('/', function () {
             // this ensures that the handler on root level are loaded for non matching routes
         });
+    }
+
+    /**
+     * Check if $callable is static
+     *
+     * A non static method will result in is_callable($callable) === true even when it is protected. This method
+     * checks if the callable is really static and callable.
+     *
+     * @param callable $callable
+     * @return bool
+     */
+    protected function isStatic(callable $callable): bool
+    {
+        if (is_array($callable)) {
+            list($class, $method) = $callable;
+        } elseif (is_string($callable) && strpos($callable, '::', 1) !== false) {
+            list($class, $method) = explode('::', $callable);
+        } else {
+            return true;
+        }
+
+        if (class_exists($class)) {
+            $classReflection = new \ReflectionClass($class);
+            $methodReflection = $classReflection->getMethod($method);
+            if (!$classReflection->isAbstract() &&
+                $methodReflection->isStatic() &&
+                $methodReflection->isPublic() &&
+                !$methodReflection->isAbstract()
+            ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/riki-dev/app/Http/RequestHandler.php
+++ b/riki-dev/app/Http/RequestHandler.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http;
+
+use App\Application;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class RequestHandler implements RequestHandlerInterface
+{
+    /** @var Application */
+    protected $app;
+
+    /** @var string */
+    protected $controller;
+
+    /** @var string */
+    protected $method;
+
+    /**
+     * RequestHandler constructor.
+     *
+     * @param Application $app
+     * @param string $controller
+     * @param string $method
+     */
+    public function __construct(Application $app, string $controller, string $method)
+    {
+        $this->app = $app;
+        $this->controller = $controller;
+        $this->method = $method;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $controller = $this->app->make($this->controller, $this->app);
+
+        if (!method_exists($controller, $this->method)) {
+            throw new \Exception(sprintf('Action %s is unknown in %s', $this->method, $this->controller));
+        }
+
+        $arguments = $request->getAttribute('arguments') ?? [];
+        return call_user_func([$controller, $this->method], $request, ...array_values($arguments));
+    }
+}

--- a/skeleton/routing/app/Http/Controller/AbstractController.php
+++ b/skeleton/routing/app/Http/Controller/AbstractController.php
@@ -6,10 +6,9 @@ use App\Application;
 use function GuzzleHttp\Psr7\stream_for;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\RequestHandlerInterface;
 use Tal\ServerResponse;
 
-abstract class AbstractController implements RequestHandlerInterface
+abstract class AbstractController
 {
     /** @var Application */
     protected $app;
@@ -24,21 +23,6 @@ abstract class AbstractController implements RequestHandlerInterface
     {
         $this->app = $app;
         $this->action = $action;
-    }
-
-    public function handle(ServerRequestInterface $request): ResponseInterface
-    {
-        $this->request = $request;
-        $action = $this->action;
-
-        if (!method_exists($this, $action)) {
-            throw new \Exception(sprintf('Action %s is unknown in %s', $action, static::class));
-        }
-
-        $arguments = $request->getAttribute('arguments') ?? [];
-        $response = call_user_func([$this, $action], ...array_values($arguments));
-
-        return $response;
     }
 
     /**

--- a/skeleton/routing/app/Http/Controller/AbstractController.php
+++ b/skeleton/routing/app/Http/Controller/AbstractController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controller;
 
 use App\Application;
 use function GuzzleHttp\Psr7\stream_for;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Tal\ServerResponse;
 

--- a/skeleton/routing/app/Http/Controller/ErrorController.php
+++ b/skeleton/routing/app/Http/Controller/ErrorController.php
@@ -2,30 +2,31 @@
 
 namespace App\Http\Controller;
 
+use Psr\Http\Message\ServerRequestInterface;
 use Tal\ServerResponse;
 
 class ErrorController extends AbstractController
 {
-    public function notFound(): ServerResponse
+    public function notFound(ServerRequestInterface $request): ServerResponse
     {
         return $this->error(404, 'File Not Found', sprintf(
             'The requested url %s is not available on this server. ' .
             'Either you misspelled the url or you clicked on a dead link.',
-            $this->request->getUri()->getPath()
+            $request->getUri()->getPath()
         ));
     }
 
-    public function methodNotAllowed(array $allowedMethods)
+    public function methodNotAllowed(ServerRequestInterface $request, array $allowedMethods)
     {
         return $this->error(405, 'Method Not Allowed', sprintf(
             'The requested method is not allowed for the resource %s.<br />' .
             'Allowed methods: %s',
-            $this->request->getUri()->getPath(),
+            $request->getUri()->getPath(),
             implode(', ', $allowedMethods)
         ));
     }
 
-    public function unexpectedError(\Throwable $exception = null): ServerResponse
+    public function unexpectedError(ServerRequestInterface $request, \Throwable $exception = null): ServerResponse
     {
         return $this->error(500, 'Unexpected Error', 'Whoops something went wrong!', $exception);
     }

--- a/skeleton/routing/app/Http/HttpKernel.php
+++ b/skeleton/routing/app/Http/HttpKernel.php
@@ -172,7 +172,7 @@ class HttpKernel extends \App\Kernel
      * @param callable $callable
      * @return bool
      */
-    protected function isStatic(callable $callable): bool
+    protected function isStatic($callable): bool
     {
         if (is_array($callable)) {
             list($class, $method) = $callable;

--- a/skeleton/routing/app/Http/HttpKernel.php
+++ b/skeleton/routing/app/Http/HttpKernel.php
@@ -82,46 +82,30 @@ class HttpKernel extends \App\Kernel
      */
     public function getHandler($handler)
     {
-        if (is_callable($handler)) {
-            switch (gettype($handler)) {
-                case 'string':
-                    if (strpos($handler, '::') === false) {
-                        return $handler;
-                    }
-                    list($class, $method) = explode('::', $handler);
-                    break;
-
-                case 'array':
-                    if (is_object($handler[0])) {
-                        return $handler;
-                    }
-                    list($class, $method) = $handler;
-                    break;
-
-                default:
-                case 'object':
-                    return $handler;
-            }
-            // for static calls we have to check more... because is callable returns true for non static methods
-            if (class_exists($class)) {
-                $class = new \ReflectionClass($class);
-                $method = $class->getMethod($method);
-                if (!$class->isAbstract() && $method->isStatic() && $method->isPublic() && !$method->isAbstract()) {
-                    return $handler;
-                }
-            }
+        if (!is_string($handler) && !is_callable($handler)) {
+            throw new \InvalidArgumentException(
+                '$handler has to be a callable, a string in form "method@Controller" or a class name'
+            );
         }
 
-        if (is_array($handler)) {
-            $class = array_shift($handler);
-            $args = $handler;
-        } elseif (is_string($handler)) {
-            $class = $handler;
-            $args = [];
-            if (1 < $pos = strpos($handler, '@')) {
-                $class = substr($handler, $pos + 1);
-                $args[] = substr($handler, 0, $pos);
+        if (is_string($handler)) {
+            if (is_callable($handler) && $this->isStatic($handler)) {
+                return $handler;
             }
+
+            $class = $handler;
+            if (($pos = strpos($handler, '@')) >= 1) {
+                $class = substr($handler, $pos + 1);
+                $method = substr($handler, 0, $pos);
+            }
+        } elseif (is_array($handler)) {
+            if (is_object($handler[0]) || $this->isStatic($handler)) {
+                return $handler;
+            }
+
+            list($class, $method) = $handler;
+        } else {
+            return $handler;
         }
 
         if (!class_exists($class)) {
@@ -131,11 +115,11 @@ class HttpKernel extends \App\Kernel
             $class = self::CONTROLLER_NAMESPACE . '\\' . $class;
         }
 
-        if (substr($class, 0, strlen(self::CONTROLLER_NAMESPACE)) === self::CONTROLLER_NAMESPACE) {
-            array_unshift($args, $this->app);
+        if (!isset($method)) {
+            return $this->app->make($class);
         }
 
-        return $this->app->make($class, ...$args);
+        return new RequestHandler($this->app, $class, $method);
     }
 
     public function getErrorHandlers(): array
@@ -149,8 +133,8 @@ class HttpKernel extends \App\Kernel
                 $request = (self::$lastRequest ?? ServerRequest::fromGlobals())
                     ->withAttribute('arguments', ['exception' => $exception]);
                 /** @var ErrorController $errorController */
-                $errorController = self::getHandler([ErrorController::class, 'unexpectedError']);
-                $errorController->handle($request)->send();
+                $handler = new RequestHandler($this->app, ErrorController::class, 'unexpectedError');
+                $handler->handle($request)->send();
                 return Handler::QUIT;
             }];
         }
@@ -177,5 +161,39 @@ class HttpKernel extends \App\Kernel
         $router->addGroup('/', function () {
             // this ensures that the handler on root level are loaded for non matching routes
         });
+    }
+
+    /**
+     * Check if $callable is static
+     *
+     * A non static method will result in is_callable($callable) === true even when it is protected. This method
+     * checks if the callable is really static and callable.
+     *
+     * @param callable $callable
+     * @return bool
+     */
+    protected function isStatic(callable $callable): bool
+    {
+        if (is_array($callable)) {
+            list($class, $method) = $callable;
+        } elseif (is_string($callable) && strpos($callable, '::', 1) !== false) {
+            list($class, $method) = explode('::', $callable);
+        } else {
+            return true;
+        }
+
+        if (class_exists($class)) {
+            $classReflection = new \ReflectionClass($class);
+            $methodReflection = $classReflection->getMethod($method);
+            if (!$classReflection->isAbstract() &&
+                $methodReflection->isStatic() &&
+                $methodReflection->isPublic() &&
+                !$methodReflection->isAbstract()
+            ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/skeleton/routing/app/Http/RequestHandler.php
+++ b/skeleton/routing/app/Http/RequestHandler.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http;
+
+use App\Application;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class RequestHandler implements RequestHandlerInterface
+{
+    /** @var Application */
+    protected $app;
+
+    /** @var string */
+    protected $controller;
+
+    /** @var string */
+    protected $method;
+
+    /**
+     * RequestHandler constructor.
+     *
+     * @param Application $app
+     * @param string $controller
+     * @param string $method
+     */
+    public function __construct(Application $app, string $controller, string $method)
+    {
+        $this->app = $app;
+        $this->controller = $controller;
+        $this->method = $method;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $controller = $this->app->make($this->controller, $this->app);
+
+        if (!method_exists($controller, $this->method)) {
+            throw new \Exception(sprintf('Action %s is unknown in %s', $this->method, $this->controller));
+        }
+
+        $arguments = $request->getAttribute('arguments') ?? [];
+        return call_user_func([$controller, $this->method], $request, ...array_values($arguments));
+    }
+}

--- a/skeleton/routing/tests/Unit/Http/Controller/ErrorControllerTest.php
+++ b/skeleton/routing/tests/Unit/Http/Controller/ErrorControllerTest.php
@@ -12,17 +12,19 @@ class ErrorControllerTest extends TestCase
     /** @test */
     public function returns500Response()
     {
+        $request = new ServerRequest('POST', '/any/path');
         $errorController = new ErrorController($this->app);
 
-        self::assertSame(500, $errorController->unexpectedError()->getStatusCode());
+        self::assertSame(500, $errorController->unexpectedError($request)->getStatusCode());
     }
 
     /** @test */
     public function rendersUnexpectedError()
     {
+        $request = new ServerRequest('POST', '/any/path');
         $errorController = new ErrorController($this->app);
 
-        $body = $errorController->unexpectedError()->getBody()->getContents();
+        $body = $errorController->unexpectedError($request)->getBody()->getContents();
 
         self::assertContains('Unexpected Error', $body);
     }
@@ -30,19 +32,19 @@ class ErrorControllerTest extends TestCase
     /** @test */
     public function returns404Response()
     {
-        $errorController = new ErrorController($this->app, 'notFound');
+        $errorController = new ErrorController($this->app);
         $request = new ServerRequest('GET', '/any/path');
 
-        self::assertSame(404, $errorController->handle($request)->getStatusCode());
+        self::assertSame(404, $errorController->notFound($request)->getStatusCode());
     }
 
     /** @test */
     public function rendersNotFoundError()
     {
-        $errorController = new ErrorController($this->app, 'notFound');
+        $errorController = new ErrorController($this->app);
         $request = new ServerRequest('GET', '/any/path');
 
-        $body = $errorController->handle($request)->getBody()->getContents();
+        $body = $errorController->notFound($request)->getBody()->getContents();
 
         self::assertContains('File Not Found', $body);
         self::assertContains('/any/path', $body);
@@ -51,21 +53,19 @@ class ErrorControllerTest extends TestCase
     /** @test */
     public function returns405Response()
     {
-        $errorController = new ErrorController($this->app, 'methodNotAllowed');
-        $request = (new ServerRequest('POST', '/any/path'))
-            ->withAttribute('arguments', ['allowedMethods' => ['GET']]);
+        $errorController = new ErrorController($this->app);
+        $request = (new ServerRequest('POST', '/any/path'));
 
-        self::assertSame(405, $errorController->handle($request)->getStatusCode());
+        self::assertSame(405, $errorController->methodNotAllowed($request, ['GET'])->getStatusCode());
     }
 
     /** @test */
     public function rendersMethodNotAllowed()
     {
-        $errorController = new ErrorController($this->app, 'methodNotAllowed');
-        $request = (new ServerRequest('POST', '/any/path'))
-            ->withAttribute('arguments', ['allowedMethods' => ['GET']]);
+        $errorController = new ErrorController($this->app);
+        $request = (new ServerRequest('POST', '/any/path'));
 
-        $body = $errorController->handle($request)->getBody()->getContents();
+        $body = $errorController->methodNotAllowed($request, ['GET'])->getBody()->getContents();
 
         self::assertContains('Method Not Allowed', $body);
         self::assertContains('/any/path', $body);

--- a/skeleton/routing/tests/Unit/Http/ControllerDispatcherTest.php
+++ b/skeleton/routing/tests/Unit/Http/ControllerDispatcherTest.php
@@ -1,38 +1,41 @@
 <?php
 
-namespace Test\Unit\Http\Controller;
+namespace Test\Unit\Http;
 
-use Mockery as m;
 use App\Http\Controller\ErrorController;
+use App\Http\RequestHandler;
+use Mockery as m;
 use Tal\ServerRequest;
 use Tal\ServerResponse;
 use Test\TestCase;
 
-class AbstractControllerTest extends TestCase
+class ControllerDispatcherTest extends TestCase
 {
     /** @test */
-    public function throwsWhenActionNotFound()
+    public function throwsWhenMethodNotFound()
     {
-        $controller = new ErrorController($this->app, 'anyMethod');
+        $handler = new RequestHandler($this->app, ErrorController::class, 'anyMethod');
 
         self::expectException(\Exception::class);
         self::expectExceptionMessage('Action anyMethod is unknown in ' . ErrorController::class);
 
-        $controller->handle(m::mock(ServerRequest::class));
+        $handler->handle(m::mock(ServerRequest::class));
     }
 
     /** @test */
     public function callsActionWithArguments()
     {
-        $controller = m::mock(ErrorController::class, [$this->app, 'unexpectedError'])->makePartial();
+        $handler = new RequestHandler($this->app, ErrorController::class, 'unexpectedError');
+        $controller = m::mock(ErrorController::class, [$this->app])->makePartial();
+        $this->app->instance(ErrorController::class, $controller);
         $request = m::mock(ServerRequest::class);
         $exception = new \Exception('Foo Bar');
 
         $request->shouldReceive('getAttribute')->with('arguments')
             ->once()->andReturn(['exception' => $exception])->ordered();
-        $controller->shouldReceive('unexpectedError')->with($exception)
+        $controller->shouldReceive('unexpectedError')->with($request, $exception)
             ->once()->andReturn(m::mock(ServerResponse::class))->ordered();
 
-        $controller->handle($request);
+        $handler->handle($request);
     }
 }


### PR DESCRIPTION
See #2 

This way the Kernel does not have to deal with the different
implementations how the controllers are build and only resolves
the form 'method@Controller' to a RequestHandler.

Breaking Changes:
- an array in form `[$class, ...$constructorArgs]` is not allowed
  anymore
- getHandler always returns a RequestHandler when the callable is not
  static (e. g. `[Controller::class, 'method']`). This is not necessary
  a breaking change but it could - have a look at what RequestHandler
  is doing.
- getHandler tries to build the class if just a class name is given
  this has to be invokable or implement MiddlewareInterface or
  RequestHandlerInterface